### PR TITLE
macOS 10.13 support

### DIFF
--- a/Create Recovery Partition Installer.app/Contents/Resources/script
+++ b/Create Recovery Partition Installer.app/Contents/Resources/script
@@ -124,7 +124,9 @@ echo "Checking $1…"
 
 
 # Find and mount InstallESD.dmg.
-if [ -f "$1/Contents/SharedSupport/InstallESD.dmg" ]; then
+if [ -f "$1/Contents/SharedSupport/BaseSystem.dmg" ]; then
+    sysdmg="$1/Contents/SharedSupport/BaseSystem.dmg"
+elif [ -f "$1/Contents/SharedSupport/InstallESD.dmg" ]; then
     sysdmg="$1/Contents/SharedSupport/InstallESD.dmg"
 elif [ -f "$1" ]; then
     sysdmg="$1"
@@ -135,6 +137,7 @@ fi
 sysvol=$( hdiutil attach -nobrowse -mountrandom /tmp -noverify "$sysdmg" | grep Apple_HFS | awk '{print $3}' )
 if [ $? -ne 0 ]; then
     error_exit "Mount of $sysdmg failed\!"
+    echo "Mount of $sysdmg failed\!"
 fi
 
 # Check system version.
@@ -189,7 +192,11 @@ plist_write "$output_pkg/Contents/Info.plist" "CFBundleShortVersionString" strin
 
 # Copy BaseSystem.* from InstallESD.
 echo "Copying BaseSystem from InstallESD.dmg…"
-cp -v "$sysvol"/BaseSystem.* "$output_pkg/Contents/Resources"
+if [ "$sysdmg" == "$1/Contents/SharedSupport/BaseSystem.dmg" ]; then
+    cp -v "$1/Contents/SharedSupport"/BaseSystem.* "$output_pkg/Contents/Resources"
+else
+    cp -v "$sysvol"/BaseSystem.* "$output_pkg/Contents/Resources"
+fi
 chflags -R nohidden "$output_pkg"
 xattr -r -d com.apple.quarantine "$output_pkg"
 

--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,8 @@ Drag and drop a 10.7+ installer onto the app and it'll create an installer packa
 
 Version History
 ---------------
-
+* 1.2
+    * 10.13 support added by Howard Griffith.
 * 1.1
     * 10.9 support added by Timothy Sutton.
 * 1.0


### PR DESCRIPTION
I have tweaked the logic of the script to allow support for 10.13+.  I have tested this with all macOS versions down to 10.10 and they successfully build the installer correctly.  I did not have a copy of the 10.7 - 10.9 installers to test with.

This will successfully build a package for macOS 10.14 beta 8, but since that version of macOS is still beta and may change I would not claim full Mojave support just yet.